### PR TITLE
FIX bestfirst decoder should also use np.intp

### DIFF
--- a/seqlearn/_decode/bestfirst.py
+++ b/seqlearn/_decode/bestfirst.py
@@ -8,7 +8,7 @@ def bestfirst(Score, trans, init, final):
 
     n_samples, _ = Score.shape
 
-    path = np.empty(n_samples, dtype=np.int32)
+    path = np.empty(n_samples, dtype=np.intp)
     path[0] = np.argmax(init + Score[0])
 
     for i in xrange(1, n_samples - 1):


### PR DESCRIPTION
StructuredPerceptron raises an exception when np.int32 is used.

The following test still fails though:

```
from seqlearn._decode import DECODERS

def test_perceptron_decoders():
    """Assert that perceptron works with all decoders."""
    for decoder in DECODERS:
        clf = StructuredPerceptron(max_iter=1, decode=decoder)
        clf.fit([[1, 2, 3]], [1], [1])  # no exception
```

```
Traceback (most recent call last):
  File "/Users/kmike/envs/scraping/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/Users/kmike/svn/seqlearn/seqlearn/tests/test_perceptron.py", line 50, in test_perceptron_decoders
    clf.fit([[1, 2, 3]], [1], [1])  # no exception
  File "/Users/kmike/svn/seqlearn/seqlearn/perceptron.py", line 112, in fit
    y_pred = decode(Score, w_trans, w_init, w_final)
  File "/Users/kmike/svn/seqlearn/seqlearn/_decode/bestfirst.py", line 17, in bestfirst
    path[-1] = np.argmax(trans[path[-2], :] + Score[-1] + final)
IndexError: index -2 is out of bounds for axis 0 with size 1

```

Also, "bestfirst" decoder is currently much slower than viterbi. 
