### PR TITLE
Fixed missing numpy headers in OS X build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,7 @@ setup_options = dict(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
     ],
-    ext_modules=["seqlearn/_decode/bestfirst.pyx",
-                 "seqlearn/_decode/viterbi.pyx",
-                 "seqlearn/_utils/ctrans.pyx",
-                 "seqlearn/_utils/safeadd.pyx"],
-    requires=["sklearn", "Cython"],
+    install_requires=["sklearn", "Cython"],
 )
 
 # FIXME: Cython doesn't exist on Heroku before pip runs. And this depends
@@ -63,7 +59,10 @@ setup_options = dict(
 # P.S. I hope some interns get a laugh out of this someday.
 try:
     from Cython.Build import cythonize
-    setup_options["ext_modules"] = cythonize(setup_options["ext_modules"])
+    setup_options["ext_modules"] = cythonize(["seqlearn/_decode/bestfirst.pyx",
+                                              "seqlearn/_decode/viterbi.pyx",
+                                              "seqlearn/_utils/ctrans.pyx",
+                                              "seqlearn/_utils/safeadd.pyx"])
 
     # NOTE: See https://github.com/hmmlearn/hmmlearn/issues/43. However,
     # cythonize doesn't pass include_path to Extension either, so we're
@@ -73,7 +72,7 @@ try:
     # they're just strings otherwise.
     for em in setup_options["ext_modules"]:
         em.include_dirs = [np.get_include()]
-    
+
 except ImportError:
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup_options = dict(
                            "seqlearn/_decode/viterbi.pyx",
                            "seqlearn/_utils/ctrans.pyx",
                            "seqlearn/_utils/safeadd.pyx"]),
-    requires=["sklearn"],
+    requires=["sklearn", "Cython"],
 )
 
 # NOTE: See https://github.com/hmmlearn/hmmlearn/issues/43. However,

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup_options = dict(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.3",
     ],
-    install_requires=["sklearn", "Cython"],
+    setup_requires=["sklearn", "Cython"],
 )
 
 # FIXME: Cython doesn't exist on Heroku before pip runs. And this depends

--- a/setup.py
+++ b/setup.py
@@ -50,12 +50,6 @@ setup_options = dict(
     requires=["sklearn", "Cython"],
 )
 
-# NOTE: See https://github.com/hmmlearn/hmmlearn/issues/43. However,
-# cythonize doesn't pass include_path to Extension either, so we're
-# hacking it directly.
-for em in setup_options["ext_modules"]:
-    em.include_dirs = [np.get_include()]
-    
 # FIXME: Cython doesn't exist on Heroku before pip runs. And this depends
 # on Cython. But we can't declare that we depend on Cython because we try
 # to import Cython before it exists and promptly exception out. So, we declare
@@ -70,6 +64,16 @@ for em in setup_options["ext_modules"]:
 try:
     from Cython.Build import cythonize
     setup_options["ext_modules"] = cythonize(setup_options["ext_modules"])
+
+    # NOTE: See https://github.com/hmmlearn/hmmlearn/issues/43. However,
+    # cythonize doesn't pass include_path to Extension either, so we're
+    # hacking it directly.
+    #
+    # NOTE: This needs to be done after the above cythonize call since
+    # they're just strings otherwise.
+    for em in setup_options["ext_modules"]:
+        em.include_dirs = [np.get_include()]
+    
 except ImportError:
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from Cython.Build import cythonize
 from distutils.core import setup
 from distutils.extension import Extension
+import numpy as np
 import os.path
 import re
 import sys
@@ -50,12 +51,10 @@ setup_options = dict(
     requires=["sklearn"],
 )
 
-# For these actions, NumPy is not required. We want them to succeed without,
-# for example when pip is used to install seqlearn without NumPy present.
-NO_NUMPY_ACTIONS = ('--help-commands', 'egg_info', '--version', 'clean')
-if not ('--help' in sys.argv[1:]
-        or len(sys.argv) > 1 and sys.argv[1] in NO_NUMPY_ACTIONS):
-    import numpy
-    setup_options['include_dirs'] = [numpy.get_include()]
+# NOTE: See https://github.com/hmmlearn/hmmlearn/issues/43. However,
+# cythonize doesn't pass include_path to Extension either, so we're
+# hacking it directly.
+for em in setup_options["ext_modules"]:
+    em.include_dirs = [np.get_include()]
 
 setup(**setup_options)


### PR DESCRIPTION
Trying to build seqlearn on OS X 10.11 results in the following error:

```
$ python setup.py install
...
clang -fno-strict-aliasing -fno-common -dynamic -g -O2 -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -I/usr/local/include -I/usr/local/opt/openssl/include -I/usr/local/opt/sqlite/include -I/usr/local/Cellar/python/2.7.10_2/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c seqlearn/_decode/bestfirst.c -o build/temp.macosx-10.10-x86_64-2.7/seqlearn/_decode/bestfirst.o
seqlearn/_decode/bestfirst.c:250:10: fatal error: 'numpy/arrayobject.h' file not found
#include "numpy/arrayobject.h"
         ^
1 error generated.
error: command 'clang' failed with exit status 1
```

Which is the same error solved here: https://github.com/hmmlearn/hmmlearn/issues/43. This ports the `hmmlearn` fix to `seqlearn`.
