### PR TITLE
Constraints on Transition Probabilities

### DIFF
--- a/seqlearn/_utils/__init__.py
+++ b/seqlearn/_utils/__init__.py
@@ -18,6 +18,7 @@ from sklearn.utils.extmath import safe_sparse_dot
 from .ctrans import count_trans
 from .safeadd import safe_add
 from .transmatrix import make_trans_matrix
+from .transmatrix import make_trans_mask
 
 
 def _assert_all_finite(X):

--- a/seqlearn/_utils/transmatrix.py
+++ b/seqlearn/_utils/transmatrix.py
@@ -23,3 +23,34 @@ def make_trans_matrix(y, n_classes, dtype=np.float64):
 
     return csr_matrix((np.ones(len(y), dtype=dtype), indices, indptr),
                       shape=(len(y), n_classes ** 2))
+
+
+def make_trans_mask(trans_constraints, classes):
+    """ Given a list of tuples that match elements in the list classes
+
+    Parameters
+    ----------
+    trans_constraints : list
+        A list of tuples of length two.  The first element is the prev_state,
+        the latter element is the current_state.  The existance of a constraint
+        pair (prev_state, current_state) significantly lowers the transition
+        probability between elements
+
+    classes : list
+        The list of classes
+
+    """
+    n_classes = len(classes)
+    classdict = {c:i for i,c in enumerate(classes)}
+
+    trans_mask = np.zeros((n_classes, n_classes), dtype=int)
+
+    for src, dest in trans_constraints:
+        r = classdict.get(src,-1)
+        c = classdict.get(dest,-1)
+
+        # Check if valid constraint
+        if r > -1 and c > -1:
+            trans_mask[r,c] = 1
+
+    return trans_mask

--- a/seqlearn/tests/test_perceptron.py
+++ b/seqlearn/tests/test_perceptron.py
@@ -1,4 +1,5 @@
 from numpy.testing import assert_array_equal
+from numpy.testing import assert_raises
 
 import numpy as np
 from scipy.sparse import coo_matrix, csc_matrix
@@ -49,3 +50,44 @@ def test_perceptron_single_iter():
     """Assert that averaging works after a single iteration."""
     clf = StructuredPerceptron(max_iter=1)
     clf.fit([[1, 2, 3]], [1], [1])  # no exception
+
+def test_perceptron_mask():
+    X = [[0, 1, 0],
+         [0, 1, 0],
+         [1, 0, 0],
+         [0, 1, 0],
+         [1, 0, 0],
+         [0, 0, 1],
+         [0, 0, 1],
+         [0, 1, 0],
+         [1, 0, 0],
+         [1, 0, 0]]
+
+    y = [0, 0, 0, 0, 0, 1, 1, 0, 2, 2]
+    
+    trans_constraints = [('spam','eggs'), ('spam', 'ham')]
+
+    clf = StructuredPerceptron(verbose=True, random_state=42, max_iter=15,
+                               trans_constraints=trans_constraints)
+
+    # Try again with string labels and sparse input.
+    y_str = np.array(["eggs", "ham", "spam"])[y]
+
+    
+    clf.fit(csc_matrix(X), y_str, [len(y_str)])
+    
+    # Still fits
+    assert_array_equal(y_str, clf.predict(coo_matrix(X)))
+    # Weights are overridden properly
+    assert_array_equal([clf.intercept_trans_[2,0], clf.intercept_trans_[2,1]], 
+                       [clf.CONSTRAINT_VALUE]*2)
+                       
+    # Add impossible constriants and model should fail to converge
+    impossible_constraints = [('spam','eggs'), ('eggs', 'ham')]
+    clf2 = StructuredPerceptron(verbose=True, random_state=12, max_iter=15,
+                               trans_constraints=impossible_constraints)
+    
+    clf2.fit(csc_matrix(X), y_str, [len(y_str)])
+    
+    # Should raise error saying that prediction is incorrect
+    assert_raises(AssertionError, assert_array_equal, y_str, clf2.predict(coo_matrix(X)))


### PR DESCRIPTION
I needed the ability to put constraints on some transition probabilities.  Namely I had to set a few transition probabilities close to 0.  Here is an initial attempt which uses `numpy.ma.masked_array` to fix some of the values in `b_trans`.  

I utilize a hyper-parameter named `trans_constraints` to provide a list of transitions that should have very low probabilities.  

I have provided a simple test to show that the constraints work. 

Any feedback would be appreciated.
