### PR TITLE
Bug in HMM normalization?

### DIFF
--- a/seqlearn/hmm.py
+++ b/seqlearn/hmm.py
@@ -68,10 +68,10 @@ class MultinomialHMM(BaseSequenceClassifier):
         final_prob -= logsumexp(final_prob)
 
         feature_prob = np.log(safe_sparse_dot(Y.T, X) + alpha)
-        feature_prob -= logsumexp(feature_prob, axis=0)
+        feature_prob -= logsumexp(feature_prob, axis=1)[:, np.newaxis]
 
         trans_prob = np.log(count_trans(y, len(classes)) + alpha)
-        trans_prob -= logsumexp(trans_prob, axis=0)
+        trans_prob -= logsumexp(trans_prob, axis=1)[:, np.newaxis]
 
         self.coef_ = feature_prob
         self.intercept_init_ = init_prob

--- a/seqlearn/tests/test_hmm.py
+++ b/seqlearn/tests/test_hmm.py
@@ -34,10 +34,10 @@ def test_hmm():
     assert_array_equal(clf.predict(X), y)
 
     n_classes = len(clf.classes_)
-    assert_array_almost_equal(np.ones(n_features),
-                              np.exp(clf.coef_).sum(axis=0))
     assert_array_almost_equal(np.ones(n_classes),
-                              np.exp(clf.intercept_trans_).sum(axis=0))
+                              np.exp(clf.coef_).sum(axis=1))
+    assert_array_almost_equal(np.ones(n_classes),
+                              np.exp(clf.intercept_trans_).sum(axis=1))
     assert_array_almost_equal(1., np.exp(clf.intercept_final_).sum())
     assert_array_almost_equal(1., np.exp(clf.intercept_init_).sum())
 


### PR DESCRIPTION
Hi,

I was trying seqlearn for a realistic problem and the HMM performance was much worse than a structured perceptron (1% vs ~30% F-score). Thinking something was wrong I even tried the implementation in NLTK which performs almost as well as the perceptron.

Upon inspecting the learned parameters I find unexpected results, while NLTK looked sensible. After going through the calculation step by step I think the problem is this; with this patch I get good performance.

I should write a failing test to actually verify that this is correct, and I will try to do so, but it might take a while to find the time...
